### PR TITLE
Fix error

### DIFF
--- a/Sugo/MPNetwork.m
+++ b/Sugo/MPNetwork.m
@@ -253,6 +253,9 @@ static const NSUInteger kBatchSize = 50;
     NSString *LinesSeperator = [NSString stringWithFormat:@"%c", 2];
 
     for (NSDictionary *object in batch) {
+        if (![object isKindOfClass:[NSDictionary class]]) {
+            continue;
+        }
         for (NSString *key in object.allKeys.reverseObjectEnumerator) {
             if (![localKeys containsObject:key]) {
                 [localKeys addObject:key];


### PR DESCRIPTION
skip object when it is not a dictionary when encode batch from array